### PR TITLE
add: build pr

### DIFF
--- a/.github/workflows/build-pr-azure.yml
+++ b/.github/workflows/build-pr-azure.yml
@@ -1,0 +1,19 @@
+name: Build and Tag Container for PR Azure
+
+on: 
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+jobs:
+  build-pr-azure:
+    uses: ca-risken/.github/.github/workflows/build-pr.yml@main
+    with:
+      runs_on: codebuild-mimosa-azure-pr-runner-${{ github.run_id }}-${{ github.run_attempt }}
+      install_go_version: "1.22.0"
+      golangci_lint_version: "v1.61.0"
+      image_prefix: "risken-azure"
+    secrets:
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+      DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}


### PR DESCRIPTION
googleに関連付けられていたcodebuildを置き換えるためにgithub actionsのワークフローを追加します。
awsやcoreのものとgolangのバージョンを除き、同じ内容です。